### PR TITLE
Remove Redundant socketTimeout Assignments

### DIFF
--- a/src/AeroSharp/DataAccess/ReadConfiguration.cs
+++ b/src/AeroSharp/DataAccess/ReadConfiguration.cs
@@ -14,7 +14,6 @@ namespace AeroSharp.DataAccess
         /// </summary>
         public ReadConfiguration()
         {
-            SocketTimeout = TimeSpan.FromSeconds(10);
             RetryCount = 2;
             ReadBatchSize = 5000;
             SendKey = false;
@@ -31,7 +30,6 @@ namespace AeroSharp.DataAccess
         /// <param name="other">Configuration to copy.</param>
         public ReadConfiguration(ReadConfiguration other)
         {
-            SocketTimeout = other.SocketTimeout;
             RetryCount = other.RetryCount;
             ReadBatchSize = other.ReadBatchSize;
             SendKey = other.SendKey;


### PR DESCRIPTION
## Description

In `ReadConfiguration`, we duplicatively assign a value to `SocketTimeout` in the constructors.

In the default constructor, we assign it a value of 10 seconds followed by 4 seconds. In this pull request, I remove the first instance (10 seconds) to leave the assignment to the effective assignment of 4 seconds.

In the overloaded (other) constructor, I remove the duplicative assignment which has no affect on the outcome.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
