### PR TITLE
Update run command for publish_preview.yml

### DIFF
--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set VERSION variable from tag
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Pack NuGet
-        run: dotnet pack src --no-build --configuration Release /p:Version=${VERSION} --output src
+        run: dotnet pack src/AeroSharp/AeroSharp.csproj --no-build --configuration Release /p:Version=${VERSION} --output src
       - name: Publish NuGet
         run: dotnet nuget push src/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_KEY} --skip-duplicate
         env:


### PR DESCRIPTION
## Description

Changing the run command for the `dotnet pack` command to reference the csproj instead of the source folder.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
