### PR TITLE
Add Check on NULL reads in ReadModifyWrite

### DIFF
--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -167,7 +167,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             // Adding this function in as a helper method to AddOrUpdate
             // Intention is to make the code in the retry simple and readable
             T result;
-            if (value is object && value.Any() && value.First().Value is object))
+            if (value is object && value.Any() && value.First().Value is object)
             {
                 // modify the record's value by first mapping the record to the object and then passing that
                 // to the updateValueFunction

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -167,7 +167,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             // Adding this function in as a helper method to AddOrUpdate
             // Intention is to make the code in the retry simple and readable
             T result;
-            if (value is object && value.Any() && value.First().Value is object)
+            if (value.First().Value is object && MapRecordsToTuple<T>(value, bin).First().Value is object)
             {
                 // modify the record's value by first mapping the record to the object and then passing that
                 // to the updateValueFunction

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -167,7 +167,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             // Adding this function in as a helper method to AddOrUpdate
             // Intention is to make the code in the retry simple and readable
             T result;
-            if (value.First().Value is object && MapRecordsToTuple<T>(value, bin).First().Value is object)
+            if (value.First().Value is object)
             {
                 T cachedValue = MapRecordsToTuple<T>(value, bin).First().Value;
 

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -169,10 +169,20 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             T result;
             if (value.First().Value is object && MapRecordsToTuple<T>(value, bin).First().Value is object)
             {
-                // modify the record's value by first mapping the record to the object and then passing that
-                // to the updateValueFunction
-                // returns the object to write down to the store
-                result = updateValueFunc(MapRecordsToTuple<T>(value, bin).First().Value);
+                T cachedValue = MapRecordsToTuple<T>(value, bin).First().Value;
+
+                if (cachedValue is object)
+                {
+                    // modify the record's value by first mapping the record to the object and then passing that
+                    // to the updateValueFunction
+                    // returns the object to write down to the store
+                    result = updateValueFunc(MapRecordsToTuple<T>(value, bin).First().Value);
+                }
+                else
+                {
+                    // if cached result is null treat identically as if new value being added
+                    result = addValueFunc();
+                }
             }
             else
             {

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -171,7 +171,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             {
                 T cachedValue = MapRecordsToTuple<T>(value, bin).First().Value;
 
-                if (!EqualityComparer<T>.Default.Equals(cachedValue, default(T)))
+                if (!Equals(cachedValue, default(T)))
                 {
                     // modify the record's value by first mapping the record to the object and then passing that
                     // to the updateValueFunction

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -166,9 +166,8 @@ namespace AeroSharp.DataAccess.KeyValueAccess
         {
             // Adding this function in as a helper method to AddOrUpdate
             // Intention is to make the code in the retry simple and readable
-
             T result;
-            if (value.First().Value is object)
+            if (value is object && value.Any() && value.First().Value is object))
             {
                 // modify the record's value by first mapping the record to the object and then passing that
                 // to the updateValueFunction

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -171,7 +171,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
             {
                 T cachedValue = MapRecordsToTuple<T>(value, bin).First().Value;
 
-                if (cachedValue is object)
+                if (!EqualityComparer<T>.Default.Equals(cachedValue, default(T)))
                 {
                     // modify the record's value by first mapping the record to the object and then passing that
                     // to the updateValueFunction

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -176,7 +176,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
                     // modify the record's value by first mapping the record to the object and then passing that
                     // to the updateValueFunction
                     // returns the object to write down to the store
-                    result = updateValueFunc(MapRecordsToTuple<T>(value, bin).First().Value);
+                    result = updateValueFunc(cachedValue);
                 }
                 else
                 {

--- a/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
+++ b/src/AeroSharp/DataAccess/KeyValueAccess/KeyValueStore.cs
@@ -146,6 +146,7 @@ namespace AeroSharp.DataAccess.KeyValueAccess
                 await WriteAsyncWithEqualGeneration(key, bin, value, generationId, timeToLive, cancellationToken);
             });
         }
+
         private Task WriteAsyncWithEqualGeneration<T>(string key, string bin, T value, int generationId, TimeSpan timeToLive, CancellationToken cancellationToken)
         {
             var config = new WriteConfiguration(_writeConfiguration);
@@ -164,8 +165,9 @@ namespace AeroSharp.DataAccess.KeyValueAccess
 
         private T GetValueToWrite<T>(Func<T> addValueFunc, Func<T, T> updateValueFunc, IEnumerable<KeyValuePair<string, Record>> value, string bin)
         {
-            // Adding this function in as a helper method to AddOrUpdate
-            // Intention is to make the code in the retry simple and readable
+            /* Adding this function in as a helper method to AddOrUpdate
+             * Intention is to make the code in the retry simple and readable
+             */
             T result;
             if (value.First().Value is object)
             {
@@ -173,9 +175,10 @@ namespace AeroSharp.DataAccess.KeyValueAccess
 
                 if (!Equals(cachedValue, default(T)))
                 {
-                    // modify the record's value by first mapping the record to the object and then passing that
-                    // to the updateValueFunction
-                    // returns the object to write down to the store
+                    /* modify the record's value by first mapping the record to
+                     * the object and then passing that to the updateValueFunction
+                     * returns the object to write down to the store
+                     */
                     result = updateValueFunc(cachedValue);
                 }
                 else

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -434,6 +434,8 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
                 WaitTimeInMilliseconds = 10,
                 WithExponentialBackoff = true
             };
+
+            await _recordOperator.DeleteAsync(UnoccupiedRecord, new WriteConfiguration(), default);
             var keyValueStore = KeyValueStoreBuilder.Configure(_clientProvider)
                 .WithDataContext(TestPreparer.TestDataContext)
                 .UseMessagePackSerializer()
@@ -472,6 +474,7 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
                 WithExponentialBackoff = true
             };
 
+            await _recordOperator.DeleteAsync(OccupiedRecord1, new WriteConfiguration(), default);
             var keyValueStore = KeyValueStoreBuilder.Configure(_clientProvider)
                 .WithDataContext(TestPreparer.TestDataContext)
                 .UseMessagePackSerializer()
@@ -491,7 +494,7 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
                 keyValueStore.ReadModifyWriteAsync(OccupiedRecord1, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default),
                 keyValueStore.ReadModifyWriteAsync(OccupiedRecord1, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default));
 
-            KeyValuePair<string, TestType> finalValue = await keyValueStore.ReadAsync(UnoccupiedRecord, default);
+            KeyValuePair<string, TestType> finalValue = await keyValueStore.ReadAsync(OccupiedRecord1, default);
             Assert.IsNull(finalValue.Value);
         }
     }

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -435,7 +435,6 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
                 WithExponentialBackoff = true
             };
 
-            await _recordOperator.DeleteAsync(UnoccupiedRecord, new WriteConfiguration(), default);
             var keyValueStore = KeyValueStoreBuilder.Configure(_clientProvider)
                 .WithDataContext(TestPreparer.TestDataContext)
                 .UseMessagePackSerializer()

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -472,15 +472,11 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
                 WithExponentialBackoff = true
             };
 
-            // The purpose of this test is to assert that a previously non-existent record
-            // can be added and modified in parallel without any issue, so let's delete
-            // any previously setup record from the set first
-            await _recordOperator.DeleteAsync(UnoccupiedRecord, new WriteConfiguration(), default);
             var keyValueStore = KeyValueStoreBuilder.Configure(_clientProvider)
                 .WithDataContext(TestPreparer.TestDataContext)
                 .UseMessagePackSerializer()
                 .WithReadModifyWriteConfiguration(rmwPolicy)
-                .Build<TestType>(UnoccupiedBin);
+                .Build<TestType>(OccupiedBin);
 
             var addValueOnTestType = new Func<TestType>(() => null);
 
@@ -492,8 +488,8 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
             });
 
             await Task.WhenAll(
-                keyValueStore.ReadModifyWriteAsync(UnoccupiedRecord, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default),
-                keyValueStore.ReadModifyWriteAsync(UnoccupiedRecord, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default));
+                keyValueStore.ReadModifyWriteAsync(OccupiedRecord1, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default),
+                keyValueStore.ReadModifyWriteAsync(OccupiedRecord1, addValueOnTestType, updateValueOnTestType, TimeSpan.FromSeconds(5), default));
 
             KeyValuePair<string, TestType> finalValue = await keyValueStore.ReadAsync(UnoccupiedRecord, default);
             Assert.IsNull(finalValue.Value);

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -26,6 +26,7 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
         {
             [Key(1)]
             public string Text { get; set; }
+
             [Key(2)]
             public int Value { get; set; }
         }


### PR DESCRIPTION
## Description
- Add an additional check on ReadModifyWrite for when read value is NULL to differentiate between cache miss and cache hit with null value

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
