### PR TITLE
Give Auto-Approve Workflow PR Write Permission

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -1,7 +1,9 @@
 name: Auto-Approve Dependabot
 on:
   pull_request:
-    branches: [ main ] 
+    branches: [ main ]
+permissions:
+  pull-requests: write
 jobs:
   dependabot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This adds pull request write permissions for the auto-approval workflow for dependabot PRs, which is needed for that workflow to work.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
