### PR TITLE
Cut v0.1.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2022-01-31
+## [0.1.2] - 2022-03-28
+
+### Added
+
+- Added README to package contents
+
+### Changed
+
+- `FluentValidation` v10.3.6 => v10.4.0
+
+## [0.1.1] - 2022-01-31
 
 ### Changed
 

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2021</Copyright>


### PR DESCRIPTION
## Description

Cuts a new v0.1.2 release, which includes packaging the `README` into the package as well as a previously merged FluentValidation update.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - new release

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
