### PR TITLE
Swap to Working NuGet Publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: dotnet build src --configuration Release --no-restore
       - name: Publish NuGet
-        uses: brandedoutcast/publish-nuget@v2.5.5
+        uses: alirezanet/publish-nuget@v3.0.3
         with:
           PROJECT_FILE_PATH: src/AeroSharp/AeroSharp.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
## Description

The [brandedoutcast/publish-nuget](https://github.com/brandedoutcast/publish-nuget) action is now partially broken with the recent Node update for GitHub actions. This action is also seemingly abandoned and unmaintained. This change cuts AeroSharp over to [alirezanet/publish-nuget](https://github.com/alirezanet/publish-nuget), which is a working and maintained fork of this same action.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
