### PR TITLE
Cut v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Aerospike.Client` v4.2.7 => v5.0.0. 
+- `Aerospike.Client` v4.2.7 => v5.0.0.
 
 See Aerospike's [C# Client Library Release Notes](https://download.aerospike.com/download/client/csharp/notes.html#5.0.0) for details on underlying core client changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2022-04-13
+
+### Changed
+
+- `Aerospike.Client` v4.2.7 => v5.0.0. 
+
+See Aerospike's [C# Client Library Release Notes](https://download.aerospike.com/download/client/csharp/notes.html#5.0.0) for details on underlying core client changes.
+
 ## [0.1.2] - 2022-03-28
 
 ### Added

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2021</Copyright>


### PR DESCRIPTION
## Description

This cuts a v0.2.0 release of this library, upgrading the internal Aerospike client to v5.0.0.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
