### PR TITLE
Add Renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,9 @@
     "dependencies",
     "renovate"
   ],
-  "timezone": "America/New_York",
+  "schedule": [
+    "before 9am on Monday"
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Description

Adds weekly schedule to Renovate config, to reduce noise from PR creation throughout the week.
Removes timezone: UTC is fine, and means these PRs will be created in advance of working hours for US-based maintainers.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (config change)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
