### PR TITLE
Fix Aerosharp.Examples and Aerosharp.HelloWorld

### DIFF
--- a/examples/AeroSharp.Examples.HelloWorld/Program.cs
+++ b/examples/AeroSharp.Examples.HelloWorld/Program.cs
@@ -26,7 +26,7 @@ namespace AeroSharp.Examples.HelloWorld
                 )
                 .Build();
 
-            var dataContext = new DataContext("test_namespace", "test_set");
+            var dataContext = new DataContext("test", "test_set");
 
             var keyValueStore = KeyValueStoreBuilder
                 .Configure(clientProvider)

--- a/examples/AeroSharp.Examples/Program.cs
+++ b/examples/AeroSharp.Examples/Program.cs
@@ -1,5 +1,10 @@
 ﻿namespace AeroSharp.Examples
 {
+    /// <summary>
+    /// Runs a suite of examples, with nicely formatted output for your viewing pleasure.
+    ///
+    /// Before running this, run `../scripts/start_aerospike_in_docker.sh` to start a preconfigured local Aerospike instance.
+    /// </summary>
     public class Program
     {
         public static void Main()

--- a/examples/AeroSharp.Examples/Utilities/ExamplesConfiguration.cs
+++ b/examples/AeroSharp.Examples/Utilities/ExamplesConfiguration.cs
@@ -2,6 +2,6 @@
 {
     internal static class ExamplesConfiguration
     {
-        public const string AerospikeNamespace = "test_namespace";
+        public const string AerospikeNamespace = "test";
     }
 }


### PR DESCRIPTION
## Description

This small change fixes our `Aerosharp.Examples` and `Aerosharp.HelloWorld` example applications so that they use the proper Aerospike namespace. 

This addresses https://github.com/wayfair-incubator/AeroSharp/issues/157.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
