### PR TITLE
Introduce ability to set maxConcurrentThreads on BulkPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-03-29
+
+### Changed
+
+- Allow users to set MaxConcurrentThreads in ReadConfiguration
+
 ## [0.3.1] - 2022-06-01
 
 ### Changed

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.2</Version>
+    <Version>0.4.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2021</Copyright>

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2021</Copyright>

--- a/src/AeroSharp/DataAccess/Policies/ReadConfigurationToBatchPolicyMapper.cs
+++ b/src/AeroSharp/DataAccess/Policies/ReadConfigurationToBatchPolicyMapper.cs
@@ -12,7 +12,8 @@ namespace AeroSharp.DataAccess.Policies
                 sendKey = configuration.SendKey,
                 sendSetName = configuration.SendSetName,
                 sleepBetweenRetries = (int)configuration.SleepBetweenRetries.TotalMilliseconds,
-                totalTimeout = (int)configuration.TotalTimeout.TotalMilliseconds
+                totalTimeout = (int)configuration.TotalTimeout.TotalMilliseconds,
+                maxConcurrentThreads = configuration.MaxConcurrentThreads
             };
     }
 }

--- a/src/AeroSharp/DataAccess/ReadConfiguration.cs
+++ b/src/AeroSharp/DataAccess/ReadConfiguration.cs
@@ -22,6 +22,7 @@ namespace AeroSharp.DataAccess
             TotalTimeout = TimeSpan.FromSeconds(10);
             SocketTimeout = TimeSpan.FromSeconds(4);
             MaxConcurrentBatches = 1;
+            MaxConcurrentThreads = 1;
         }
 
         /// <summary>
@@ -38,6 +39,7 @@ namespace AeroSharp.DataAccess
             TotalTimeout = other.TotalTimeout;
             SocketTimeout = other.SocketTimeout;
             MaxConcurrentBatches = other.MaxConcurrentBatches;
+            MaxConcurrentThreads = other.MaxConcurrentThreads;
         }
 
         /// <summary>
@@ -78,5 +80,11 @@ namespace AeroSharp.DataAccess
         /// If set to 1, batches are read sequentially. Must be >= 1.
         /// </summary>
         public int MaxConcurrentBatches { get; set; }
+        /// <summary>
+        /// Maximum number of concurrent synchronous batch node request threads to server nodes.
+        /// Asynchronous batch requests ignore this field and always issue all node requests in parallel.
+        /// Must be >= 0.
+        /// </summary>
+        public int MaxConcurrentThreads { get; set; }
     }
 }

--- a/src/AeroSharp/DataAccess/Validation/ReadConfigurationValidator.cs
+++ b/src/AeroSharp/DataAccess/Validation/ReadConfigurationValidator.cs
@@ -11,6 +11,7 @@ namespace AeroSharp.DataAccess.Validation
             RuleFor(x => x.SocketTimeout.TotalMilliseconds).GreaterThanOrEqualTo(TimeSpan.FromMilliseconds(0).TotalMilliseconds);
             RuleFor(x => x.RetryCount).GreaterThanOrEqualTo(0);
             RuleFor(x => x.MaxConcurrentBatches).GreaterThanOrEqualTo(1);
+            RuleFor(x => x.MaxConcurrentThreads).GreaterThanOrEqualTo(0);
         }
     }
 }

--- a/tests/AeroSharp.UnitTests/DataAccess/Policies/ReadConfigurationToBatchPolicyMapperTests.cs
+++ b/tests/AeroSharp.UnitTests/DataAccess/Policies/ReadConfigurationToBatchPolicyMapperTests.cs
@@ -20,7 +20,8 @@ namespace AeroSharp.UnitTests.DataAccess.Policies
                 SendKey = true,
                 SendSetName = true,
                 SleepBetweenRetries = TimeSpan.FromMilliseconds(1000),
-                TotalTimeout = TimeSpan.FromMilliseconds(2000)
+                TotalTimeout = TimeSpan.FromMilliseconds(2000),
+                MaxConcurrentThreads = 1
             };
 
             var result = ReadConfigurationToBatchPolicyMapper.MapToPolicy(config);
@@ -30,6 +31,7 @@ namespace AeroSharp.UnitTests.DataAccess.Policies
             result.sendSetName.Should().Be(config.SendSetName);
             result.sleepBetweenRetries.Should().Be((int)config.SleepBetweenRetries.TotalMilliseconds);
             result.totalTimeout.Should().Be((int)config.TotalTimeout.TotalMilliseconds);
+            result.maxConcurrentThreads.Should().Be(config.MaxConcurrentThreads);
         }
     }
 }


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

This change seeks to allow users of the Aerosharp library to set the parameter on Bulk Policy called maxConcurrentThreads.  By default, this property is set to 1, meaning that all commands to Aerospike are handled sequentially.

The objective here on my end is to expose this setting (keeping it defaulted to 1), but enabling it to be set to 0 - allowing for users to send commands to then be distributed across all available Aerospike nodes within the cluster.

This is a fairly benign change, hopefully - just looking to expose this variable for others to set if they see fit!

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
