### PR TITLE
Upgrade Aerospike client and Aerosharp to target .net6 and .net7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Publish Code Coverage
         uses: codecov/codecov-action@v3
         with:
-          files: /home/runner/work/AeroSharp/AeroSharp/coverage.opencover.xml
+          files: /home/runner/work/AeroSharp/AeroSharp/coverage.net7.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net6.0.opencover.xml
           fail_ci_if_error: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Publish Code Coverage
         uses: codecov/codecov-action@v3
         with:
-          files: /home/runner/work/AeroSharp/AeroSharp/coverage.opencover.xml
+          files: /home/runner/work/AeroSharp/AeroSharp/coverage.net7.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net6.0.opencover.xml
           fail_ci_if_error: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2023-03-29
+
+### Changed
+
+- Target .net6 and .net7 frameworks
+- `Aerospike.Client` v5.1.1 => 6.0.0
+
+Our first major release!  This looks to upgrade the package with some of the performance improvements in .net6 and
+includes all of the additional changes/improvements from Aerospike in their latest client version.
+
+## [0.4.0] - 2023-03-29
+
+### Changed
+
+- Allow users to set MaxConcurrentThreads in ReadConfiguration
+
 ## [0.3.1] - 2022-06-01
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ requests after 60 days of inactivity.
 
 Please note that all of your interactions in the project are subject to our [Code of Conduct](CODE_OF_CONDUCT.md). This
 includes creation of issues or pull requests, commenting on issues or pull requests, and extends to all interactions in
-any real-time space (eg. Slack, Discord, etc).
+any real-time space (eg. Slack, Discord, etc).  We follow the general git-paradigm for contributions to this repo, you can read about it [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962)!
 
 ## Reporting Issues
 

--- a/examples/AeroSharp.Examples.HelloWorld/AeroSharp.Examples.HelloWorld.csproj
+++ b/examples/AeroSharp.Examples.HelloWorld/AeroSharp.Examples.HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/AeroSharp.Examples/AeroSharp.Examples.csproj
+++ b/examples/AeroSharp.Examples/AeroSharp.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/start_aerospike_in_docker.sh
+++ b/scripts/start_aerospike_in_docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -d --name aerospike -e "NAMESPACE=test" -p 3000-3002:3000-3002 aerospike:ce-5.7.0.8
+docker run -d --name aerospike -e "NAMESPACE=test" -p 3000-3002:3000-3002 aerospike:ce-6.2.0.7

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -1,47 +1,42 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.1</Version>
-    <Authors>Wayfair</Authors>
-    <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
-    <Copyright>Wayfair ©2021</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageProjectUrl>https://github.com/wayfair-incubator/AeroSharp</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/wayfair-incubator/AeroSharp</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>aerospike, aerosharp, serialization, policy validation</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Remove="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="5.1.1" />
-    <PackageReference Include="FluentValidation" Version="11.0.3" />
-    <PackageReference Include="lz4net" Version="1.0.15.93" />
-    <PackageReference Include="MessagePack" Version="2.3.112" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="protobuf-net" Version="3.1.4" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
- 
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Version>1.0.0</Version>
+		<Authors>Wayfair</Authors>
+		<Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
+		<Copyright>Wayfair ©2023</Copyright>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageProjectUrl>https://github.com/wayfair-incubator/AeroSharp</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/wayfair-incubator/AeroSharp</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>aerospike, aerosharp, serialization, policy validation</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Include="..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath/>
+		</None>
+		<None Remove="stylecop.json"/>
+	</ItemGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json"/>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Aerospike.Client" Version="6.0.0"/>
+		<PackageReference Include="FluentValidation" Version="11.0.3"/>
+		<PackageReference Include="lz4net" Version="1.0.15.93"/>
+		<PackageReference Include="MessagePack" Version="2.3.112"/>
+		<PackageReference Include="Polly" Version="7.2.3"/>
+		<PackageReference Include="protobuf-net" Version="3.1.4"/>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="5.1.1" />
+    <PackageReference Include="Aerospike.Client" Version="6.0.0" />
     <PackageReference Include="FluentValidation" Version="11.0.3" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="MessagePack" Version="2.3.112" />

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -1,42 +1,47 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.0.0</Version>
-		<Authors>Wayfair</Authors>
-		<Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
-		<Copyright>Wayfair ©2023</Copyright>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageProjectUrl>https://github.com/wayfair-incubator/AeroSharp</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/wayfair-incubator/AeroSharp</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>aerospike, aerosharp, serialization, policy validation</PackageTags>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
-	<ItemGroup>
-		<None Include="..\..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-		<None Include="..\..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath/>
-		</None>
-		<None Remove="stylecop.json"/>
-	</ItemGroup>
-	<ItemGroup>
-		<AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json"/>
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Aerospike.Client" Version="6.0.0"/>
-		<PackageReference Include="FluentValidation" Version="11.0.3"/>
-		<PackageReference Include="lz4net" Version="1.0.15.93"/>
-		<PackageReference Include="MessagePack" Version="2.3.112"/>
-		<PackageReference Include="Polly" Version="7.2.3"/>
-		<PackageReference Include="protobuf-net" Version="3.1.4"/>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <Authors>Wayfair</Authors>
+    <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
+    <Copyright>Wayfair ©2023</Copyright>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/wayfair-incubator/AeroSharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/wayfair-incubator/AeroSharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>aerospike, aerosharp, serialization, policy validation</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Remove="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aerospike.Client" Version="5.1.1" />
+    <PackageReference Include="FluentValidation" Version="11.0.3" />
+    <PackageReference Include="lz4net" Version="1.0.15.93" />
+    <PackageReference Include="MessagePack" Version="2.3.112" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="protobuf-net" Version="3.1.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+ 
 </Project>

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.0.0</Version>
     <Authors>Wayfair</Authors>

--- a/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
+++ b/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
+++ b/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AeroSharp.Tests/AeroSharp.Tests.csproj
+++ b/tests/AeroSharp.Tests/AeroSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
+++ b/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

A major upgrade to the client - this looks to upgrade the Aerosharp client to .net6 and the Aerospike client 6.0.0, as discussed in #162.

I made this change and all of our tests (integration included) passed fine, since I believe they were recently upgraded to .net6 on their own.


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
