### PR TITLE
Adding a new public method to fetch readonly Nodes from client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2023-04-11
+## [1.1.0] - 2023-04-11
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2023-04-11
+
+### Changed
+
+Introduced fetching of an Array of Node for an aerospike client.
+
 ## [1.0.0] - 2023-03-29
 
 ### Changed

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2023</Copyright>

--- a/src/AeroSharp/Connection/ClientProvider.cs
+++ b/src/AeroSharp/Connection/ClientProvider.cs
@@ -26,16 +26,6 @@ namespace AeroSharp.Connection
             _hosts = connection.BootstrapServers.Select(s => new Host(s, connection.Port)).ToArray();
         }
 
-        public Node[] GetNodes()
-        {
-            if (_client is null || !_client.Client.Connected)
-            {
-                _ = GetClient();
-            }
-
-            return _client.GetClientNodes();
-        }
-
         public ClientWrapper GetClient()
         {
             if (_client is null || !_client.Client.Connected)

--- a/src/AeroSharp/Connection/ClientProvider.cs
+++ b/src/AeroSharp/Connection/ClientProvider.cs
@@ -26,6 +26,16 @@ namespace AeroSharp.Connection
             _hosts = connection.BootstrapServers.Select(s => new Host(s, connection.Port)).ToArray();
         }
 
+        public Node[] GetNodes()
+        {
+            if (_client is null || !_client.Client.Connected)
+            {
+                _ = GetClient();
+            }
+
+            return _client.GetClientNodes();
+        }
+
         public ClientWrapper GetClient()
         {
             if (_client is null || !_client.Client.Connected)

--- a/src/AeroSharp/Connection/ClientWrapper.cs
+++ b/src/AeroSharp/Connection/ClientWrapper.cs
@@ -17,9 +17,6 @@ namespace AeroSharp.Connection
             Client = client;
         }
 
-        public Node[] GetClientNodes()
-        {
-            return Client.Nodes;
-        }
+        public Node[] ClientNodes => Client.Nodes;
     }
 }

--- a/src/AeroSharp/Connection/ClientWrapper.cs
+++ b/src/AeroSharp/Connection/ClientWrapper.cs
@@ -16,5 +16,10 @@ namespace AeroSharp.Connection
 
             Client = client;
         }
+
+        public Node[] GetClientNodes()
+        {
+            return Client.Nodes;
+        }
     }
 }

--- a/src/AeroSharp/Connection/IClientProvider.cs
+++ b/src/AeroSharp/Connection/IClientProvider.cs
@@ -9,11 +9,5 @@ namespace AeroSharp.Connection
         /// </summary>
         /// <returns>A <see cref="ClientWrapper"/></returns>
         ClientWrapper GetClient();
-
-        /// <summary>
-        /// Get an Array of Node for an Aerospike client.
-        /// </summary>
-        /// <returns>Array of Node</returns>
-        Node[] GetNodes();
     }
 }

--- a/src/AeroSharp/Connection/IClientProvider.cs
+++ b/src/AeroSharp/Connection/IClientProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace AeroSharp.Connection
+﻿using Aerospike.Client;
+
+namespace AeroSharp.Connection
 {
     public interface IClientProvider
     {
@@ -7,5 +9,11 @@
         /// </summary>
         /// <returns>A <see cref="ClientWrapper"/></returns>
         ClientWrapper GetClient();
+
+        /// <summary>
+        /// Get an Array of Node for an Aerospike client.
+        /// </summary>
+        /// <returns>Array of Node</returns>
+        Node[] GetNodes();
     }
 }

--- a/src/AeroSharp/Connection/IClientProvider.cs
+++ b/src/AeroSharp/Connection/IClientProvider.cs
@@ -1,6 +1,4 @@
-﻿using Aerospike.Client;
-
-namespace AeroSharp.Connection
+﻿namespace AeroSharp.Connection
 {
     public interface IClientProvider
     {

--- a/tests/AeroSharp.IntegrationTests/Connection/ClientWrapperTest.cs
+++ b/tests/AeroSharp.IntegrationTests/Connection/ClientWrapperTest.cs
@@ -1,0 +1,21 @@
+﻿using AeroSharp.Tests.Utility;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace AeroSharp.IntegrationTests.Connection
+{
+    [TestFixture]
+    [Category("Aerospike")]
+    public class ClientWrapperTest
+    {
+        [Test]
+        public void Getting_nodes_from_clientWrapper_Should_return_value()
+        {
+            var clientProvider = TestPreparer.PrepareTest();
+
+            var nodes = clientProvider.GetClient().ClientNodes;
+
+            nodes.Length.Should().BeGreaterThanOrEqualTo(1);
+        }
+    }
+}

--- a/tests/AeroSharp.Tests/Utility/TestPreparer.cs
+++ b/tests/AeroSharp.Tests/Utility/TestPreparer.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using AeroSharp.Connection;
+﻿using AeroSharp.Connection;
 using AeroSharp.DataAccess;
-using Aerospike.Client;
+using System;
 
 namespace AeroSharp.Tests.Utility
 {

--- a/tests/AeroSharp.Tests/Utility/TestPreparer.cs
+++ b/tests/AeroSharp.Tests/Utility/TestPreparer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AeroSharp.Connection;
 using AeroSharp.DataAccess;
+using Aerospike.Client;
 
 namespace AeroSharp.Tests.Utility
 {
@@ -30,6 +31,11 @@ namespace AeroSharp.Tests.Utility
                 }
 
                 return _instance;
+            }
+
+            public Node[] GetNodes()
+            {
+                return GetClient().GetClientNodes();
             }
         }
 

--- a/tests/AeroSharp.Tests/Utility/TestPreparer.cs
+++ b/tests/AeroSharp.Tests/Utility/TestPreparer.cs
@@ -32,11 +32,6 @@ namespace AeroSharp.Tests.Utility
 
                 return _instance;
             }
-
-            public Node[] GetNodes()
-            {
-                return GetClient().GetClientNodes();
-            }
         }
 
         private static readonly string[] BootstrapServers = { "127.0.0.1" };


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

This PR is introducing a public method in ClientWrapper to fetch read-only property "Node" of Aerospike client. As there has been instances where we wanted to have more visibility around Active Connections for a given Node of an aerospike client.

This functionality will enable different users to monitor the busy and available connections as well as any other insights into the Nodes of a client.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
