### PR TITLE
Upgrade Aerospike C# Client

### DIFF
--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
-    <Copyright>Wayfair ©2023</Copyright>
+    <Copyright>Wayfair ©2024</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/wayfair-incubator/AeroSharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/wayfair-incubator/AeroSharp</RepositoryUrl>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="6.0.1" />
+    <PackageReference Include="Aerospike.Client" Version="7.0.1" />
     <PackageReference Include="FluentValidation" Version="11.6.0" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="MessagePack" Version="2.5.124" />


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

So as far as I can tell, this is a non-breaking major version upgrade for the Aerospike Client.  I am not 100% certain in what this release contains given the lack of documentation on the Aerospike side, but this seems to mostly be a refactor on their end: https://github.com/aerospike/aerospike-client-csharp/commit/c9b39e3d3689f76e16db86c2b58bb1385da33d10?diff=split&w=1 

Unfortunately, without that extra information (request sent out to the team to find out more), I'm just going based off of our robust tests and reading the above commit.  From what I can tell however, there are a lot of changes from cleanup, refactor, and actual feature changes.

For example: [Disposal Management?](https://github.com/aerospike/aerospike-client-csharp/commit/c9b39e3d3689f76e16db86c2b58bb1385da33d10?diff=split&w=1#diff-7737a4876a7be81e0263938bf5c34f9fa07e2548c69eb054b82fa5b997f10458R336)

The only "Breaking Change" according to the website ([here](https://aerospike.com/developer/client/incompatible#version-700)) could impact us with `Aerospike boolean particle type` which I will look into a bit more.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
