### PR TITLE
Fix for integration test failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check Out Code
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.0.x
@@ -26,15 +26,21 @@ jobs:
         run: dotnet build src --configuration Release --no-restore
       - name: Set up Aerospike Database
         uses: reugn/github-action-aerospike@v1.1.0
+        with:
+          server-version: 6.2.0.7
       - name: Integration Tests
         run: |
-          cd ./tests/AeroSharp.IntegrationTests/
-          dotnet test --no-restore -nodereuse:false \
-            /p:UseSharedCompilation=false \
-            /p:UseRazorBuildServer=false \
-            /p:CollectCoverage=true \
-            /p:CoverletOutputFormat=opencover \
-            /p:CoverletOutput=/home/runner/work/AeroSharp/AeroSharp/ \
+          for tfm in net6.0 net7.0; do
+            dotnet test tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj \
+              --framework "$tfm" --configuration Release --no-restore -nodereuse:false \
+              /p:UseSharedCompilation=false \
+              /p:UseRazorBuildServer=false \
+              /p:ParallelizeTestCollections=false \
+              /p:CollectCoverage=true \
+              /p:CoverletOutputFormat=opencover \
+              /p:CoverletOutput=/home/runner/work/AeroSharp/AeroSharp/ \
+              || exit 1
+          done   
       # - name: Publish Code Coverage
       #   uses: codecov/codecov-action@v3
       #   with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
               /p:CollectCoverage=true \
               /p:CoverletOutputFormat=opencover \
               /p:CoverletOutput=/home/runner/work/AeroSharp/AeroSharp/ \
-              || exit 1
+              || exit $?
           done   
       # - name: Publish Code Coverage
       #   uses: codecov/codecov-action@v3

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -78,7 +78,7 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
             var result = await keyValueStore.ReadAsync<TestType>(OccupiedRecord1, OccupiedBin, default);
             result.Key.Should().Be(OccupiedRecord1);
             result.Value.Text.Should().BeEquivalentTo(_testData.Text);
-            result.Value.Value.Should().NotBe(_testData.Value);
+            result.Value.Value.Should().Be(_testData.Value);
         }
 
         [Test]

--- a/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
+++ b/tests/AeroSharp.IntegrationTests/DataAccess/KeyValue/KeyValueStoreTests.cs
@@ -78,7 +78,7 @@ namespace AeroSharp.IntegrationTests.DataAccess.KeyValue
             var result = await keyValueStore.ReadAsync<TestType>(OccupiedRecord1, OccupiedBin, default);
             result.Key.Should().Be(OccupiedRecord1);
             result.Value.Text.Should().BeEquivalentTo(_testData.Text);
-            result.Value.Value.Should().Be(_testData.Value);
+            result.Value.Value.Should().NotBe(_testData.Value);
         }
 
         [Test]


### PR DESCRIPTION
## Description
I don't want to call this a bug fix per se - this PR looks to update the integration.yml file to only do one target framework at a time.  My best understanding of the issue is that since we're using the same base Aerospike set in the container, we may, perhaps, be overriding changes from the .net6 run and the .net7 run.  

This PR adds a for loop to the integration.yml integration test run step.

As we can see below, there's really nothing that changed code wise here such that the tests started to fail.  The best assumption is either the ubuntu:latest usage or just Github workers for GHA - regardless, it's a finicky pickle!
<img width="1153" height="688" alt="Screenshot 2026-04-03 at 9 51 16 PM" src="https://github.com/user-attachments/assets/b9d439c7-7c3e-4d98-afea-145b1066c188" />


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
