### PR TITLE
Renovate/nuget packages minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-12
+
+### Changed
+
+- `Aerospike.Client` v6.0.1 => v6.2.2
+- `FluentValidation` v11.6.0 => v11.12.0
+- `MessagePack` v2.5.124 => v2.5.198
+- `protobuf-net` v3.2.26 => v3.2.56
+- Test dependencies: `coverlet.msbuild`, `FluentAssertions`, `Moq`, `nunit`, `NUnit3TestAdapter`, `Microsoft.NET.Test.Sdk` (17.11.1; newer 17.x drops `net6.0` / `net7.0` test TFMs)
+
 ## [1.1.1] - 2024-08-12
 
 ### Changed

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,10 +1,10 @@
 {
     "name": "aerosharp-docs",
     "description": "Documentation generator for the AeroSharp C# package",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "",
     "dependencies": {
-        "js-yaml": "4.1.0"
+        "js-yaml": "4.1.1"
     },
     "license": "MIT"
 }

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2024</Copyright>

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="6.0.1" />
-    <PackageReference Include="FluentValidation" Version="11.6.0" />
+    <PackageReference Include="Aerospike.Client" Version="6.2.2" />
+    <PackageReference Include="FluentValidation" Version="11.12.0" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />
-    <PackageReference Include="MessagePack" Version="2.5.124" />
+    <PackageReference Include="MessagePack" Version="2.5.198" />
     <PackageReference Include="Polly" Version="7.2.4" />
-    <PackageReference Include="protobuf-net" Version="3.2.26" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
+++ b/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
@@ -9,15 +9,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
+++ b/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
+++ b/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
@@ -9,15 +9,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
+++ b/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
Consolidating two Renovate PR's https://github.com/wayfair-incubator/AeroSharp/pull/183 and https://github.com/wayfair-incubator/AeroSharp/pull/196

## Summary

Fork-based PR (no access to Renovate’s branch on `wayfair-incubator`). Intended to supersede **[Renovate PR #183](https://github.com/wayfair-incubator/AeroSharp/pull/183)** with the same dependency bumps plus release metadata and a test SDK fix.

## Changes

- **Production NuGet bumps** in `src/AeroSharp/AeroSharp.csproj` (e.g. `Aerospike.Client`, `FluentValidation`, `MessagePack`, `protobuf-net`, etc.) per Renovate minor/patch group.
- **Test project bumps** (`FluentAssertions`, `Moq`, `nunit`, `NUnit3TestAdapter`, `coverlet.msbuild`, etc.).
- **`Microsoft.NET.Test.Sdk` set to `17.11.1`** in unit and integration test projects. **`17.14.x` breaks builds** for `net6.0` / `net7.0` test TFMs (SDK explicitly errors on unsupported TFMs).
- **Package version `1.2.0`** in `AeroSharp.csproj` (Renovate does not bump semver).
- **`CHANGELOG.md`** — new `[1.2.0]` entry documenting dependency updates and the Test.Sdk note.

## Testing

```bash
dotnet test tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj -c Release

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass