### PR TITLE
Add net8 and net10 targets for AS v8+

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build
@@ -27,10 +27,10 @@ jobs:
       - name: Set up Aerospike Database
         uses: reugn/github-action-aerospike@v1.1.0
         with:
-          server-version: 6.2.0.7
+          server-version: 8.1.2.1
       - name: Integration Tests
         run: |
-          for tfm in net6.0 net7.0; do
+          for tfm in net8.0 net10.0; do
             dotnet test tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj \
               --framework "$tfm" --configuration Release --no-restore -nodereuse:false \
               /p:UseSharedCompilation=false \
@@ -40,9 +40,9 @@ jobs:
               /p:CoverletOutputFormat=opencover \
               /p:CoverletOutput=/home/runner/work/AeroSharp/AeroSharp/ \
               || exit $?
-          done   
+          done
       # - name: Publish Code Coverage
       #   uses: codecov/codecov-action@v3
       #   with:
-      #     files: /home/runner/work/AeroSharp/AeroSharp/coverage.net7.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net6.0.opencover.xml
+      #     files: /home/runner/work/AeroSharp/AeroSharp/coverage.net8.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net10.0.opencover.xml
       #     fail_ci_if_error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,14 +11,14 @@ jobs:
       name: "Publish Release"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check Out Code
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -17,14 +17,14 @@ jobs:
       name: "Publish Preview"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check Out Code
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check Out Code
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
       - name: Restore Dependencies
         run: dotnet restore src
       - name: Build
@@ -36,5 +36,5 @@ jobs:
       # - name: Publish Code Coverage
       #   uses: codecov/codecov-action@v3
       #   with:
-      #     files: /home/runner/work/AeroSharp/AeroSharp/coverage.net7.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net6.0.opencover.xml
+      #     files: /home/runner/work/AeroSharp/AeroSharp/coverage.net8.0.opencover.xml,/home/runner/work/AeroSharp/AeroSharp/coverage.net10.0.opencover.xml
       #     fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-06-11
+
+### Changed
+
+- Target frameworks updated from `.NET 6/.NET 7` to `.NET 8/.NET 10` (dual-targeting).
+- Upgraded `Aerospike.Client` from `6.0.1` to `8.4.1`.
+- Updated local/CI Aerospike server version to `8.1.2.1`.
+- Preserved legacy boolean bin encoding behavior (`Value.UseBoolBin = false`) to avoid data type changes for existing records during the client upgrade.
+
+### Migration Notes
+
+- **Minimum requirement**: .NET 8 (required by Aerospike.Client 8.1+)
+- **Recommended**: .NET 10 LTS (supported until November 2028)
+- This is a **breaking change** for applications targeting .NET 6/.NET 7
+
 ## [1.1.1] - 2024-08-12
 
 ### Changed

--- a/examples/AeroSharp.Examples.HelloWorld/AeroSharp.Examples.HelloWorld.csproj
+++ b/examples/AeroSharp.Examples.HelloWorld/AeroSharp.Examples.HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/AeroSharp.Examples/AeroSharp.Examples.csproj
+++ b/examples/AeroSharp.Examples/AeroSharp.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/AeroSharp.Examples/README.md
+++ b/examples/AeroSharp.Examples/README.md
@@ -14,4 +14,6 @@ To run examples for the project locally, first start up Aerospike in a local Doc
 
 After doing this, the examples will connect to your local Aerospike instance and everything should "just work"!
 
-Examples can be run from the project root with `dotnet run --framework net7.0 --project examples/AeroSharp.Examples/AeroSharp.Examples.csproj` or via your .NET IDE of choice.
+Examples can be run from the project root with `dotnet run --framework net10.0 --project examples/AeroSharp.Examples/AeroSharp.Examples.csproj` (recommended) or `dotnet run --framework net8.0 --project examples/AeroSharp.Examples/AeroSharp.Examples.csproj` or via your .NET IDE of choice.
+
+**Note**: .NET 10 is recommended as it's the current LTS release with support until November 2028.

--- a/scripts/start_aerospike_in_docker.sh
+++ b/scripts/start_aerospike_in_docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -d --name aerospike -e "NAMESPACE=test" -p 3000-3002:3000-3002 aerospike:ce-6.2.0.7
+docker run -d --name aerospike -e "NAMESPACE=test" -p 3000-3002:3000-3002 aerospike:ce-8.1.2.1

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.1</Version>
+    <Version>2.0.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2024</Copyright>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="6.0.1" />
+    <PackageReference Include="Aerospike.Client" Version="8.4.1" />
     <PackageReference Include="FluentValidation" Version="11.6.0" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="MessagePack" Version="2.5.124" />

--- a/src/AeroSharp/Connection/ClientProvider.cs
+++ b/src/AeroSharp/Connection/ClientProvider.cs
@@ -13,6 +13,9 @@ namespace AeroSharp.Connection
         internal ClientProvider(ConnectionContext connection, Credentials credentials, ConnectionConfiguration configuration)
         {
             _lock = new object();
+            // Preserve pre-7.0 client behavior so booleans continue to be stored as integers.
+            // This avoids data-type drift for existing records when upgrading Aerospike.Client.
+            Value.UseBoolBin = false;
 
             _policy = new AsyncClientPolicy
             {

--- a/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
+++ b/tests/AeroSharp.IntegrationTests/AeroSharp.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AeroSharp.IntegrationTests/README.md
+++ b/tests/AeroSharp.IntegrationTests/README.md
@@ -14,6 +14,8 @@ To run integration tests for the project locally, first start up Aerospike in a 
 
 After doing this, the tests will connect to your local Aerospike instance and everything should "just work"!
 
+The Docker script currently starts `aerospike:ce-8.1.2.1`.
+
 Tests can be run from the project root with `dotnet test` or via your .NET IDE of choice.
 
 ## Adding New Tests

--- a/tests/AeroSharp.Tests/AeroSharp.Tests.csproj
+++ b/tests/AeroSharp.Tests/AeroSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
+++ b/tests/AeroSharp.UnitTests/AeroSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

It's been quite a while since we last updated the library (https://github.com/wayfair-incubator/AeroSharp/pull/164).  This PR looks to grab the latest-ish Aerospike version (v8+: https://github.com/aerospike/aerospike-client-csharp/releases) and start the process to get things a bit more up to date.  At the very least here, really trying to just get .net10 out there for this library so that we have a bit of an easier time in the future to make this a simpler update.

v8.1.0 is also the first client version to now require .net8 minimum.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe): updating targets and client version

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/AeroSharp/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
