### PR TITLE
Deprecate ReadConfiguration.SendSetName for Aerospike.Client 6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-14
+
+### Changed
+
+- Deprecated `ReadConfiguration.SendSetName`; Aerospike.Client 6+ always sends the set name, so this property has no effect.
+
 ## [1.2.0] - 2026-05-12
 
 ### Changed

--- a/src/AeroSharp/AeroSharp.csproj
+++ b/src/AeroSharp/AeroSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Wayfair</Authors>
     <Description>Wrapper around the .NET Aerospike client that provides a variety of methods for storing and retrieving data in Aerospike</Description>
     <Copyright>Wayfair ©2024</Copyright>

--- a/src/AeroSharp/DataAccess/Policies/ReadConfigurationToBatchPolicyMapper.cs
+++ b/src/AeroSharp/DataAccess/Policies/ReadConfigurationToBatchPolicyMapper.cs
@@ -10,7 +10,6 @@ namespace AeroSharp.DataAccess.Policies
                 socketTimeout = (int)configuration.SocketTimeout.TotalMilliseconds,
                 maxRetries = configuration.RetryCount,
                 sendKey = configuration.SendKey,
-                sendSetName = configuration.SendSetName,
                 sleepBetweenRetries = (int)configuration.SleepBetweenRetries.TotalMilliseconds,
                 totalTimeout = (int)configuration.TotalTimeout.TotalMilliseconds,
                 maxConcurrentThreads = configuration.MaxConcurrentThreads

--- a/src/AeroSharp/DataAccess/ReadConfiguration.cs
+++ b/src/AeroSharp/DataAccess/ReadConfiguration.cs
@@ -17,7 +17,6 @@ namespace AeroSharp.DataAccess
             RetryCount = 2;
             ReadBatchSize = 5000;
             SendKey = false;
-            SendSetName = false;
             SleepBetweenRetries = TimeSpan.Zero;
             TotalTimeout = TimeSpan.FromSeconds(10);
             SocketTimeout = TimeSpan.FromSeconds(4);
@@ -34,7 +33,6 @@ namespace AeroSharp.DataAccess
             RetryCount = other.RetryCount;
             ReadBatchSize = other.ReadBatchSize;
             SendKey = other.SendKey;
-            SendSetName = other.SendSetName;
             SleepBetweenRetries = other.SleepBetweenRetries;
             TotalTimeout = other.TotalTimeout;
             SocketTimeout = other.SocketTimeout;
@@ -67,6 +65,7 @@ namespace AeroSharp.DataAccess
         /// Send set name field to server for every key in the batch for batch index protocol.
         /// This is only necessary when authentication is enabled and security roles are defined on a per set basis.
         /// </summary>
+        [Obsolete("Deprecated. Aerospike.Client 6+ always sends the set name; this property has no effect.")]
         public bool SendSetName { get; set; }
         /// <summary>
         /// Milliseconds to sleep between retries. Enter zero to skip sleep. This field is ignored when maxRetries is zero.

--- a/tests/AeroSharp.UnitTests/DataAccess/Policies/ReadConfigurationToBatchPolicyMapperTests.cs
+++ b/tests/AeroSharp.UnitTests/DataAccess/Policies/ReadConfigurationToBatchPolicyMapperTests.cs
@@ -18,7 +18,6 @@ namespace AeroSharp.UnitTests.DataAccess.Policies
                 SocketTimeout = TimeSpan.FromMilliseconds(5000),
                 RetryCount = 3,
                 SendKey = true,
-                SendSetName = true,
                 SleepBetweenRetries = TimeSpan.FromMilliseconds(1000),
                 TotalTimeout = TimeSpan.FromMilliseconds(2000),
                 MaxConcurrentThreads = 1
@@ -28,7 +27,6 @@ namespace AeroSharp.UnitTests.DataAccess.Policies
             result.socketTimeout.Should().Be((int)config.SocketTimeout.TotalMilliseconds);
             result.maxRetries.Should().Be(config.RetryCount);
             result.sendKey.Should().Be(config.SendKey);
-            result.sendSetName.Should().Be(config.SendSetName);
             result.sleepBetweenRetries.Should().Be((int)config.SleepBetweenRetries.TotalMilliseconds);
             result.totalTimeout.Should().Be((int)config.TotalTimeout.TotalMilliseconds);
             result.maxConcurrentThreads.Should().Be(config.MaxConcurrentThreads);


### PR DESCRIPTION
## Summary
- Remove obsolete `BatchPolicy.sendSetName` mapping that caused CS0618 build warnings after the 1.2.0 Aerospike.Client upgrade
- Mark `ReadConfiguration.SendSetName` as obsolete since Aerospike.Client 6+ always sends the set name
- Bump package version to 1.3.0

## Test plan
- [x] `dotnet build` succeeds without CS0618 warnings
- [x] `ReadConfigurationToBatchPolicyMapperTests` passes on net6.0 and net7.0

Made with [Cursor](https://cursor.com)